### PR TITLE
Apply improvements to plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,19 @@
-# cdb-empleo
+# CdB Empleo
+
+Plugin para gestionar ofertas de empleo en WordPress.
+
+## Instalación
+1. Copia la carpeta `cdb-empleo` en `wp-content/plugins/`.
+2. Activa el plugin desde el panel de administración de WordPress.
+
+## Shortcodes
+- `[cdb_form_oferta]`: muestra el formulario para registrar ofertas (usuarios con rol **Empleador**).
+- `[cdb_listado_ofertas posts_per_page="10"]`: lista las ofertas publicadas.
+- `[cdb_empleo_suscritos]`: muestra las ofertas en las que el usuario actual está inscrito.
+
+## Roles y capacidades
+Al activarse se crea el rol **Empleador** con permisos para crear y gestionar ofertas.
+
+## Traducciones
+El textdomain del plugin es `cdb-empleo`. Coloca los archivos `.mo` en la carpeta `languages` dentro del plugin.
+

--- a/assets/js/script-ofertas.js
+++ b/assets/js/script-ofertas.js
@@ -64,7 +64,7 @@ jQuery(document).ready(function($) {
         // Preparar datos para el envío vía AJAX.
         var formData = new FormData(this);
         $.ajax({
-            url: ajaxurl, // ajaxurl se define mediante wp_localize_script
+            url: cdbEmpleo.ajaxurl, // definido mediante wp_localize_script
             type: "POST",
             data: formData,
             processData: false,

--- a/cdb-empleo.php
+++ b/cdb-empleo.php
@@ -17,6 +17,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 define( 'CDB_EMPLEO_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CDB_EMPLEO_URL', plugin_dir_url( __FILE__ ) );
 
+/**
+ * Carga el textdomain para las traducciones.
+ */
+function cdb_empleo_load_textdomain() {
+    load_plugin_textdomain( 'cdb-empleo', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+}
+add_action( 'plugins_loaded', 'cdb_empleo_load_textdomain' );
+
 // Incluir archivos necesarios
 require_once CDB_EMPLEO_PATH . 'includes/cpt-oferta-empleo.php';
 require_once CDB_EMPLEO_PATH . 'includes/metaboxes.php';

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -11,9 +11,9 @@ function cdb_guardar_oferta_callback() {
     // Verificar el nonce de seguridad.
     check_ajax_referer( 'cdb_form_nonce', 'security' );
 
-   // Verificar que el usuario esté conectado y tenga el rol "Empleador" o "administrator"
+   // Verificar que el usuario esté conectado y tenga permisos para crear ofertas
     $current_user = wp_get_current_user();
-    if ( ! $current_user->exists() || ( ! in_array( 'empleador', (array) $current_user->roles ) && ! in_array( 'administrator', (array) $current_user->roles ) ) ) {
+    if ( ! $current_user->exists() || ! current_user_can( 'create_oferta_empleo' ) ) {
         wp_send_json_error( array( 'message' => 'No tienes permisos para realizar esta acción.' ) );
     }
 
@@ -30,6 +30,13 @@ function cdb_guardar_oferta_callback() {
     // Validar que se hayan completado todos los campos requeridos.
     if ( empty( $bar_id ) || empty( $posicion_id ) || empty( $tipo_oferta ) || empty( $fecha_incorporacion ) || empty( $fecha_fin ) || $nivel_salarial === '' || empty( $funciones ) ) {
         wp_send_json_error( array( 'message' => 'Por favor, completa todos los campos requeridos.' ) );
+    }
+
+    // Verificar coherencia de las fechas
+    $inicio_ts = strtotime( $fecha_incorporacion );
+    $fin_ts    = strtotime( $fecha_fin );
+    if ( false !== $inicio_ts && false !== $fin_ts && $inicio_ts >= $fin_ts ) {
+        wp_send_json_error( array( 'message' => 'La fecha de incorporación debe ser anterior a la fecha de fin.' ) );
     }
 
     // Crear un título para la oferta (por ejemplo, combinando el nombre del bar y el tipo de oferta).

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -15,20 +15,25 @@ function cdb_empleo_enqueue_scripts() {
         '1.0.0'
     );
 
-    // Encolar el script para funcionalidades personalizadas, como el autocomplete.
-    wp_enqueue_script(
-        'cdb-empleo-script',
-        CDB_EMPLEO_URL . 'assets/js/script-ofertas.js',
-        array( 'jquery', 'jquery-ui-autocomplete' ),
-        '1.0.0',
-        true
-    );
+    // Cargar los scripts solo en páginas que utilicen el formulario de ofertas.
+    if ( is_singular() ) {
+        global $post;
+        if ( isset( $post->post_content ) && has_shortcode( $post->post_content, 'cdb_form_oferta' ) ) {
+            wp_enqueue_script(
+                'cdb-empleo-script',
+                CDB_EMPLEO_URL . 'assets/js/script-ofertas.js',
+                array( 'jquery', 'jquery-ui-autocomplete' ),
+                '1.0.0',
+                true
+            );
 
-    wp_localize_script(
-        'cdb-empleo-script',
-        'ajaxurl',
-        admin_url( 'admin-ajax.php' )
-    );
+            wp_localize_script(
+                'cdb-empleo-script',
+                'cdbEmpleo',
+                array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) )
+            );
+        }
+    }
 
 }
 add_action( 'wp_enqueue_scripts', 'cdb_empleo_enqueue_scripts' );


### PR DESCRIPTION
## Summary
- document plugin usage in README
- load textdomain for translations
- add capability check and date validation in AJAX handler
- load scripts only when shortcode is present
- use localized JS object for AJAX URL

## Testing
- `php -l` on all PHP files
- `node -e "require('fs').readFileSync('assets/js/script-ofertas.js')"`

------
https://chatgpt.com/codex/tasks/task_e_688561c24b948327a0bfbeebd374a477