### PR TITLE
Centralize configurable user messages for job offers

### DIFF
--- a/assets/js/script-ofertas.js
+++ b/assets/js/script-ofertas.js
@@ -80,13 +80,13 @@ jQuery(document).ready(function($) {
                 $btn.prop("disabled", false);
                 if (response.success) {
                     $("#cdb_oferta_mensaje")
-                        .attr('class', 'cdb-empleo-mensaje cdb-empleo-mensaje-exito')
+                        .attr('class', 'cdb-empleo-mensaje cdb-empleo-mensaje-success')
                         .html("<p>" + response.data.message + "</p>");
                     if (response.data.reload) {
                         window.location.reload();
                     }
                 } else {
-                    var errorMsg = response.message || (response.data && response.data.message) || 'Ocurrió un error.';
+                    var errorMsg = response.message || (response.data && response.data.message) || mensajes.error_generico || 'Ocurrió un error.';
                     $("#cdb_oferta_mensaje")
                         .attr('class', 'cdb-empleo-mensaje cdb-empleo-mensaje-error')
                         .html("<p>Error: " + errorMsg + "</p>");

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -14,7 +14,7 @@ function cdb_guardar_oferta_callback() {
    // Verificar que el usuario esté conectado y tenga permisos para crear ofertas
     $current_user = wp_get_current_user();
     if ( ! $current_user->exists() || ! current_user_can( 'create_oferta_empleo' ) ) {
-        wp_send_json_error( array( 'message' => 'No tienes permisos para realizar esta acción.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje( 'sin_permisos', __( 'No tienes permisos para realizar esta acción.', 'cdb-empleo' ) ) ) );
     }
 
 
@@ -29,14 +29,14 @@ function cdb_guardar_oferta_callback() {
 
     // Validar que se hayan completado todos los campos requeridos.
     if ( empty( $bar_id ) || empty( $posicion_id ) || empty( $tipo_oferta ) || empty( $fecha_incorporacion ) || empty( $fecha_fin ) || $nivel_salarial === '' || empty( $funciones ) ) {
-        wp_send_json_error( array( 'message' => 'Por favor, completa todos los campos requeridos.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje( 'campos_requeridos', __( 'Por favor, completa todos los campos requeridos.', 'cdb-empleo' ) ) ) );
     }
 
     // Verificar coherencia de las fechas
     $inicio_ts = strtotime( $fecha_incorporacion );
     $fin_ts    = strtotime( $fecha_fin );
     if ( false !== $inicio_ts && false !== $fin_ts && $inicio_ts >= $fin_ts ) {
-        wp_send_json_error( array( 'message' => 'La fecha de incorporación debe ser anterior a la fecha de fin.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje( 'fecha_incorrecta', __( 'La fecha de incorporación debe ser anterior a la fecha de fin.', 'cdb-empleo' ) ) ) );
     }
 
     // Crear un título para la oferta (por ejemplo, combinando el nombre del bar y el tipo de oferta).
@@ -55,7 +55,7 @@ function cdb_guardar_oferta_callback() {
     $post_id = wp_insert_post( $post_data );
 
     if ( is_wp_error( $post_id ) ) {
-        wp_send_json_error( array( 'message' => 'Error al crear la oferta.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje( 'error_crear_oferta', __( 'Error al crear la oferta.', 'cdb-empleo' ) ) ) );
     }
 
     // Guardar los campos personalizados como meta.
@@ -68,7 +68,7 @@ function cdb_guardar_oferta_callback() {
     update_post_meta( $post_id, 'cdb_funciones', $funciones );
 
     wp_send_json_success( array(
-        'message' => 'Oferta de empleo registrada exitosamente.',
+        'message' => cdb_empleo_get_mensaje( 'oferta_creada', __( 'Oferta de empleo registrada exitosamente.', 'cdb-empleo' ) ),
         'post_id' => $post_id,
         'reload'  => true, // Indica si se debe recargar la página
     ) );

--- a/includes/config-mensajes.php
+++ b/includes/config-mensajes.php
@@ -192,25 +192,26 @@ function cdb_empleo_mensajes_frontend_assets() {
         'campos_requeridos' => cdb_empleo_get_mensaje( 'campos_requeridos', __( 'Por favor, completa todos los campos requeridos.', 'cdb-empleo' ) ),
         'fecha_incorrecta'  => cdb_empleo_get_mensaje( 'fecha_incorrecta', __( 'La fecha y hora de incorporación debe ser anterior a la fecha y hora de fin.', 'cdb-empleo' ) ),
         'error_solicitud'   => cdb_empleo_get_mensaje( 'error_solicitud', __( 'Error en la solicitud.', 'cdb-empleo' ) ),
+        'error_generico'    => cdb_empleo_get_mensaje( 'error_generico', __( 'Ocurrió un error.', 'cdb-empleo' ) ),
     );
 
     wp_localize_script( 'cdb-empleo-script', 'cdbEmpleoMensajes', $mensajes );
 }
 add_action( 'wp_enqueue_scripts', 'cdb_empleo_mensajes_frontend_assets', 20 );
 
-// Registrar algunos tipos por defecto.
+// Registrar tipos base y mensajes configurables.
 cdb_empleo_register_tipo_color(
-    'exito',
+    'success',
     array(
         'label' => __( 'Éxito', 'cdb-empleo' ),
         'color' => '#28a745',
     )
 );
 cdb_empleo_register_tipo_color(
-    'aviso',
+    'info',
     array(
-        'label' => __( 'Aviso', 'cdb-empleo' ),
-        'color' => '#ffc107',
+        'label' => __( 'Info', 'cdb-empleo' ),
+        'color' => '#17a2b8',
     )
 );
 cdb_empleo_register_tipo_color(
@@ -218,6 +219,126 @@ cdb_empleo_register_tipo_color(
     array(
         'label' => __( 'Error', 'cdb-empleo' ),
         'color' => '#dc3545',
+    )
+);
+
+cdb_empleo_register_tipo_color(
+    'login_required',
+    array(
+        'label' => __( 'Login requerido', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'sin_permisos',
+    array(
+        'label' => __( 'Sin permisos', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'campos_requeridos',
+    array(
+        'label' => __( 'Campos requeridos', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'fecha_incorrecta',
+    array(
+        'label' => __( 'Fecha incorrecta', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'error_solicitud',
+    array(
+        'label' => __( 'Error solicitud', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'error_generico',
+    array(
+        'label' => __( 'Error genérico', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'error_crear_oferta',
+    array(
+        'label' => __( 'Error al crear oferta', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'oferta_creada',
+    array(
+        'label' => __( 'Oferta creada', 'cdb-empleo' ),
+        'color' => '#28a745',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'ya_suscrito',
+    array(
+        'label' => __( 'Ya suscrito', 'cdb-empleo' ),
+        'color' => '#dc3545',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'suscripcion_ok',
+    array(
+        'label' => __( 'Suscripción correcta', 'cdb-empleo' ),
+        'color' => '#28a745',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'suscripcion_eliminada',
+    array(
+        'label' => __( 'Suscripción eliminada', 'cdb-empleo' ),
+        'color' => '#28a745',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'no_suscripciones',
+    array(
+        'label' => __( 'Sin suscripciones', 'cdb-empleo' ),
+        'color' => '#17a2b8',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'no_ofertas_disponibles',
+    array(
+        'label' => __( 'No hay ofertas disponibles', 'cdb-empleo' ),
+        'color' => '#17a2b8',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'no_ofertas',
+    array(
+        'label' => __( 'No hay ofertas', 'cdb-empleo' ),
+        'color' => '#17a2b8',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'oferta_comenzada',
+    array(
+        'label' => __( 'Oferta comenzada', 'cdb-empleo' ),
+        'color' => '#17a2b8',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'faltan_dias_horas',
+    array(
+        'label' => __( 'Cuenta atrás', 'cdb-empleo' ),
+        'color' => '#17a2b8',
+    )
+);
+cdb_empleo_register_tipo_color(
+    'no_suscripciones_oferta',
+    array(
+        'label' => __( 'Oferta sin suscripciones', 'cdb-empleo' ),
+        'color' => '#17a2b8',
     )
 );
 

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -80,7 +80,7 @@ function cdb_empleo_listado_shortcode( $atts ) {
         echo '</div>';
         wp_reset_postdata();
     } else {
-        echo '<p>No hay ofertas disponibles.</p>';
+        echo cdb_empleo_render_mensaje( 'no_ofertas_disponibles', 'info', __( 'No hay ofertas disponibles.', 'cdb-empleo' ) );
     }
     
     return ob_get_clean();
@@ -106,7 +106,7 @@ function cdb_oferta_suscripcion_shortcode( $atts ) {
 
     // Verificar si el usuario está logueado.
     if ( ! is_user_logged_in() ) {
-        return '<p>Debes iniciar sesión para suscribirte a esta oferta.</p>';
+        return cdb_empleo_render_mensaje( 'login_required', 'error', __( 'Debes iniciar sesión para suscribirte a esta oferta.', 'cdb-empleo' ), false );
     }
 
     $user_id = get_current_user_id();
@@ -117,7 +117,7 @@ function cdb_oferta_suscripcion_shortcode( $atts ) {
 
     // Verificar si el usuario ya está suscrito.
     if ( in_array( $user_id, $suscripciones ) ) {
-        return '<p>Ya estás suscrito a esta oferta.</p>';
+        return cdb_empleo_render_mensaje( 'ya_suscrito', 'error', __( 'Ya estás suscrito a esta oferta.', 'cdb-empleo' ), false );
     }
 
     // Procesar la suscripción al recibir el formulario
@@ -128,7 +128,7 @@ function cdb_oferta_suscripcion_shortcode( $atts ) {
         $suscripciones[] = $user_id;
         update_post_meta( $oferta_id, '_cdb_oferta_inscripciones', $suscripciones );
 
-        return '<p>¡Te has suscrito correctamente a la oferta!</p>';
+        return cdb_empleo_render_mensaje( 'suscripcion_ok', 'success', __( '¡Te has suscrito correctamente a la oferta!', 'cdb-empleo' ), false );
     }
 
     // Mostrar el formulario de suscripción
@@ -169,7 +169,7 @@ function cdb_ofertas_inscripciones_meta_box_callback( $post ) {
 
     // Si no es un array o está vacío, mostramos un mensaje
     if ( ! is_array( $suscripciones ) || empty( $suscripciones ) ) {
-        echo '<p>No hay suscripciones para esta oferta.</p>';
+        cdb_empleo_render_mensaje( 'no_suscripciones_oferta', 'info', __( 'No hay suscripciones para esta oferta.', 'cdb-empleo' ) );
         return;
     }
 
@@ -194,7 +194,7 @@ function cdb_ofertas_inscripciones_meta_box_callback( $post ) {
 function cdb_empleo_suscritos_shortcode( $atts ) {
     // Verificar que el usuario esté logueado
     if ( ! is_user_logged_in() ) {
-        return '<p>Debes iniciar sesión para ver tus ofertas suscritas.</p>';
+        return cdb_empleo_render_mensaje( 'login_required', 'error', __( 'Debes iniciar sesión para ver tus ofertas suscritas.', 'cdb-empleo' ), false );
     }
 
     $user_id = get_current_user_id();
@@ -217,7 +217,7 @@ function cdb_empleo_suscritos_shortcode( $atts ) {
         if ( $key !== false ) {
             unset( $suscripciones[$key] );
             update_post_meta( $oferta_id_to_remove, '_cdb_oferta_inscripciones', $suscripciones );
-            $mensaje_accion = '<p>Has eliminado tu suscripción a la oferta.</p>';
+            $mensaje_accion = cdb_empleo_render_mensaje( 'suscripcion_eliminada', 'success', __( 'Has eliminado tu suscripción a la oferta.', 'cdb-empleo' ), false );
         }
     }
 
@@ -241,7 +241,7 @@ function cdb_empleo_suscritos_shortcode( $atts ) {
 
     // 3) Si no hay ofertas, avisar
     if ( ! $query->have_posts() ) {
-        return $mensaje_accion . '<p>No estás suscrito a ninguna oferta de empleo.</p>';
+        return $mensaje_accion . cdb_empleo_render_mensaje( 'no_suscripciones', 'info', __( 'No estás suscrito a ninguna oferta de empleo.', 'cdb-empleo' ), false );
     }
 
     // 4) Mostrar la lista de ofertas con posibilidad de eliminar la suscripción
@@ -264,15 +264,12 @@ function cdb_empleo_suscritos_shortcode( $atts ) {
                 $now = new DateTime( 'now', wp_timezone() );
                 $interval = $now->diff( $oferta_datetime );
                 if ( $interval->invert ) {
-                    $countdown_text = '<p class="countdown">La oferta ya ha comenzado.</p>';
+                    $countdown_text = '<p class="countdown">' . esc_html( cdb_empleo_get_mensaje( 'oferta_comenzada', __( 'La oferta ya ha comenzado.', 'cdb-empleo' ) ) ) . '</p>';
                 } else {
                     $days  = $interval->days;
                     $hours = $interval->h;
-                    $countdown_text = sprintf(
-                        '<p class="countdown">Faltan %d días y %d horas para el inicio de la oferta.</p>',
-                        $days,
-                        $hours
-                    );
+                    $template = cdb_empleo_get_mensaje( 'faltan_dias_horas', __( 'Faltan %d días y %d horas para el inicio de la oferta.', 'cdb-empleo' ) );
+                    $countdown_text = '<p class="countdown">' . sprintf( esc_html( $template ), $days, $hours ) . '</p>';
                 }
             }
         }

--- a/templates/archive-oferta_empleo.php
+++ b/templates/archive-oferta_empleo.php
@@ -55,7 +55,7 @@ get_header(); ?>
         ?>
         
     <?php else : ?>
-        <p>No hay ofertas de empleo publicadas.</p>
+        <?php cdb_empleo_render_mensaje( 'no_ofertas', 'info', __( 'No hay ofertas de empleo publicadas.', 'cdb-empleo' ) ); ?>
     <?php endif; ?>
 </div>
 

--- a/templates/form-oferta-template.php
+++ b/templates/form-oferta-template.php
@@ -7,13 +7,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Verificar si el usuario está conectado.
 $current_user = wp_get_current_user();
 if ( ! $current_user->exists() ) {
-    echo '<p>Debes iniciar sesión para gestionar ofertas de empleo.</p>';
+    cdb_empleo_render_mensaje( 'login_required', 'error', __( 'Debes iniciar sesión para gestionar ofertas de empleo.', 'cdb-empleo' ) );
     return;
 }
 
 // Verificar si el usuario tiene el rol "Empleador" o "Administrator"
 if ( ! in_array( 'empleador', (array) $current_user->roles ) && ! in_array( 'administrator', (array) $current_user->roles ) ) {
-    echo '<p></p>';
+    cdb_empleo_render_mensaje( 'sin_permisos', 'error', __( 'No tienes permisos para gestionar ofertas de empleo.', 'cdb-empleo' ) );
     return;
 }
 


### PR DESCRIPTION
## Summary
- register and expose configurable messages and base alert types
- replace hardcoded texts with `cdb_empleo_get_mensaje`/`cdb_empleo_render_mensaje`
- surface localized strings for JavaScript validation

## Testing
- `php -l includes/config-mensajes.php`
- `php -l includes/ajax-handlers.php`
- `php -l includes/shortcodes.php`
- `php -l templates/form-oferta-template.php`
- `php -l templates/archive-oferta_empleo.php`


------
https://chatgpt.com/codex/tasks/task_e_6893becc3520832792a055d5155f4625