### PR TITLE
Add configurable notice system

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -1,0 +1,40 @@
+.cdb-aviso {
+    padding: 10px;
+    border-radius: 4px;
+    margin: 5px 0;
+}
+.cdb-aviso .cdb-mensaje-principal {
+    font-weight: bold;
+}
+.cdb-aviso .cdb-mensaje-secundario {
+    display: block;
+    font-size: 0.9em;
+}
+.cdb-mensaje-row {
+    border: 1px solid #ddd;
+    padding: 10px;
+    margin-bottom: 15px;
+    background: #fff;
+}
+.cdb-aviso-preview {
+    margin-bottom: 10px;
+}
+
+.cdb-tipo-color-row {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    margin-bottom: 6px;
+}
+.cdb-tipo-color-row input[type="text"] {
+    width: 120px;
+}
+.cdb-color-swatch {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    margin-right: 4px;
+}
+.cdb-tipo-color-row.deleting {
+    opacity: 0.5;
+}

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -1,0 +1,44 @@
+jQuery(document).ready(function($){
+    $('.cdb-mensaje-input').on('input', function(){
+        var target = $('#' + $(this).data('preview'));
+        var html = '<div class="cdb-aviso">' + $(this).val() + '</div>';
+        if(target.length){
+            var existing = target.find('.cdb-aviso');
+            if(existing.length){
+                existing.find('.cdb-mensaje-principal').text($(this).val());
+            } else {
+                target.html(html);
+            }
+        }
+    });
+    $('.cdb-mostrar-checkbox').on('change', function(){
+        var target = $('#' + $(this).data('preview'));
+        if(target.length){
+            target.toggle(this.checked);
+        }
+    });
+
+    $('#cdb-add-tipo-color').on('click', function(e){
+        e.preventDefault();
+        var idx = $('#cdb-tipos-color .cdb-tipo-color-row').length + 1;
+        var row = $('<div class="cdb-tipo-color-row"></div>');
+        row.append('<span class="cdb-color-swatch" style="background-color:#000000"></span>');
+        row.append('<input type="text" name="tipos_color[new_'+idx+'][nombre]" placeholder="'+cdbEmpleoMensajes.nuevoNombre+'" />');
+        row.append('<input type="text" name="tipos_color[new_'+idx+'][class]" placeholder="'+cdbEmpleoMensajes.nuevaClase+'" />');
+        row.append('<input type="color" name="tipos_color[new_'+idx+'][color]" value="#000000" />');
+        row.append('<input type="color" name="tipos_color[new_'+idx+'][text]" value="#ffffff" />');
+        row.append('<label><input type="checkbox" name="tipos_color[new_'+idx+'][delete]" value="1" /> '+cdbEmpleoMensajes.eliminar+'</label>');
+        $('#cdb-tipos-color').append(row);
+    });
+
+    $('#cdb-tipos-color').on('change', 'input[type="checkbox"]', function(){
+        $(this).closest('.cdb-tipo-color-row').toggleClass('deleting', this.checked);
+    });
+
+    $('#cdb-tipos-color').on('input', 'input[type="color"]', function(){
+        var swatch = $(this).closest('.cdb-tipo-color-row').find('.cdb-color-swatch');
+        if(swatch.length){
+            swatch.css('background-color', $(this).val());
+        }
+    });
+});

--- a/assets/js/script-ofertas.js
+++ b/assets/js/script-ofertas.js
@@ -43,7 +43,7 @@ jQuery(document).ready(function($) {
             }
         });
         if (!valid) {
-            $("#cdb_oferta_mensaje").html("<p>Por favor, completa todos los campos requeridos.</p>");
+            $("#cdb_oferta_mensaje").html('<p>' + cdbEmpleo.mensajes.campos_requeridos + '</p>');
             isSubmitting = false;
             $btn.prop("disabled", false);
             return;
@@ -55,7 +55,7 @@ jQuery(document).ready(function($) {
         var dateIncorporacion = new Date(fechaIncorporacion);
         var dateFin = new Date(fechaFin);
         if (dateIncorporacion >= dateFin) {
-            $("#cdb_oferta_mensaje").html("<p>La fecha y hora de incorporación debe ser anterior a la fecha y hora de fin.</p>");
+            $("#cdb_oferta_mensaje").html('<p>' + cdbEmpleo.mensajes.fecha_invalida + '</p>');
             isSubmitting = false;
             $btn.prop("disabled", false);
             return;
@@ -79,7 +79,7 @@ jQuery(document).ready(function($) {
                         window.location.reload();
                     }
                 } else {
-                    var errorMsg = response.message || (response.data && response.data.message) || 'Ocurrió un error.';
+                    var errorMsg = response.message || (response.data && response.data.message) || cdbEmpleo.mensajes.error_generico;
                     $("#cdb_oferta_mensaje").html("<p>Error: " + errorMsg + "</p>");
                 }
             },
@@ -87,7 +87,7 @@ jQuery(document).ready(function($) {
                 console.error("Error:", error);
                 isSubmitting = false;
                 $btn.prop("disabled", false);
-                $("#cdb_oferta_mensaje").html("<p>Error en la solicitud.</p>");
+                $("#cdb_oferta_mensaje").html('<p>' + cdbEmpleo.mensajes.error_solicitud + '</p>');
             }
         });
     });

--- a/cdb-empleo.php
+++ b/cdb-empleo.php
@@ -30,6 +30,8 @@ require_once CDB_EMPLEO_PATH . 'includes/cpt-oferta-empleo.php';
 require_once CDB_EMPLEO_PATH . 'includes/metaboxes.php';
 require_once CDB_EMPLEO_PATH . 'includes/ajax-handlers.php';
 require_once CDB_EMPLEO_PATH . 'includes/roles-permisos.php';
+require_once CDB_EMPLEO_PATH . 'includes/messages.php';
+require_once CDB_EMPLEO_PATH . 'includes/config-mensajes.php';
 require_once CDB_EMPLEO_PATH . 'includes/scripts.php';
 require_once CDB_EMPLEO_PATH . 'includes/shortcodes.php';
 require_once CDB_EMPLEO_PATH . 'includes/funciones.php';

--- a/includes/ajax-handlers.php
+++ b/includes/ajax-handlers.php
@@ -14,7 +14,7 @@ function cdb_guardar_oferta_callback() {
    // Verificar que el usuario esté conectado y tenga permisos para crear ofertas
     $current_user = wp_get_current_user();
     if ( ! $current_user->exists() || ! current_user_can( 'create_oferta_empleo' ) ) {
-        wp_send_json_error( array( 'message' => 'No tienes permisos para realizar esta acción.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje_text( 'sin_permiso_form' ) ) );
     }
 
 
@@ -29,14 +29,14 @@ function cdb_guardar_oferta_callback() {
 
     // Validar que se hayan completado todos los campos requeridos.
     if ( empty( $bar_id ) || empty( $posicion_id ) || empty( $tipo_oferta ) || empty( $fecha_incorporacion ) || empty( $fecha_fin ) || $nivel_salarial === '' || empty( $funciones ) ) {
-        wp_send_json_error( array( 'message' => 'Por favor, completa todos los campos requeridos.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje_text( 'campos_requeridos' ) ) );
     }
 
     // Verificar coherencia de las fechas
     $inicio_ts = strtotime( $fecha_incorporacion );
     $fin_ts    = strtotime( $fecha_fin );
     if ( false !== $inicio_ts && false !== $fin_ts && $inicio_ts >= $fin_ts ) {
-        wp_send_json_error( array( 'message' => 'La fecha de incorporación debe ser anterior a la fecha de fin.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje_text( 'fecha_invalida' ) ) );
     }
 
     // Crear un título para la oferta (por ejemplo, combinando el nombre del bar y el tipo de oferta).
@@ -55,7 +55,7 @@ function cdb_guardar_oferta_callback() {
     $post_id = wp_insert_post( $post_data );
 
     if ( is_wp_error( $post_id ) ) {
-        wp_send_json_error( array( 'message' => 'Error al crear la oferta.' ) );
+        wp_send_json_error( array( 'message' => cdb_empleo_get_mensaje_text( 'error_crear_oferta' ) ) );
     }
 
     // Guardar los campos personalizados como meta.
@@ -68,7 +68,7 @@ function cdb_guardar_oferta_callback() {
     update_post_meta( $post_id, 'cdb_funciones', $funciones );
 
     wp_send_json_success( array(
-        'message' => 'Oferta de empleo registrada exitosamente.',
+        'message' => cdb_empleo_get_mensaje_text( 'oferta_registrada' ),
         'post_id' => $post_id,
         'reload'  => true, // Indica si se debe recargar la página
     ) );

--- a/includes/config-mensajes.php
+++ b/includes/config-mensajes.php
@@ -1,0 +1,161 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Register admin menu and page for message configuration.
+ */
+function cdb_empleo_mensajes_admin_menu() {
+    // Ensure main menu exists
+    add_menu_page(
+        __( 'CdB Empleo', 'cdb-empleo' ),
+        __( 'CdB Empleo', 'cdb-empleo' ),
+        'manage_options',
+        'cdb-empleo',
+        '__return_null',
+        'dashicons-id',
+        26
+    );
+
+    add_submenu_page(
+        'cdb-empleo',
+        __( 'Configuración de Mensajes y Avisos', 'cdb-empleo' ),
+        __( 'Mensajes', 'cdb-empleo' ),
+        'manage_options',
+        'cdb-empleo-config-mensajes',
+        'cdb_empleo_config_mensajes_page'
+    );
+}
+add_action( 'admin_menu', 'cdb_empleo_mensajes_admin_menu' );
+
+/**
+ * Enqueue assets for the configuration page.
+ */
+function cdb_empleo_mensajes_admin_enqueue( $hook ) {
+    if ( 'cdb-empleo_page_cdb-empleo-config-mensajes' !== $hook ) {
+        return;
+    }
+    wp_enqueue_style( 'cdb-empleo-mensajes', CDB_EMPLEO_URL . 'assets/css/config-mensajes.css', array(), '1.0.0' );
+    wp_enqueue_script( 'cdb-empleo-config-mensajes', CDB_EMPLEO_URL . 'assets/js/config-mensajes.js', array( 'jquery' ), '1.0.0', true );
+    wp_localize_script(
+        'cdb-empleo-config-mensajes',
+        'cdbEmpleoMensajes',
+        array(
+            'nuevoNombre' => __( 'Nombre', 'cdb-empleo' ),
+            'nuevaClase'  => __( 'Clase CSS', 'cdb-empleo' ),
+            'eliminar'    => __( 'Eliminar', 'cdb-empleo' ),
+        )
+    );
+}
+add_action( 'admin_enqueue_scripts', 'cdb_empleo_mensajes_admin_enqueue' );
+
+/**
+ * Render the configuration page.
+ */
+function cdb_empleo_config_mensajes_page() {
+    $mensajes_defaults = cdb_empleo_get_mensajes_defaults();
+    $tipos_color       = cdb_empleo_get_tipos_color();
+
+    // Map of keys to labels
+    $mensajes = array(
+        'login_requerido'     => __( 'Login requerido', 'cdb-empleo' ),
+        'ya_suscrito'         => __( 'Ya suscrito', 'cdb-empleo' ),
+        'suscripcion_ok'      => __( 'Suscripción correcta', 'cdb-empleo' ),
+        'suscripcion_eliminada' => __( 'Suscripción eliminada', 'cdb-empleo' ),
+        'sin_ofertas'         => __( 'Sin ofertas', 'cdb-empleo' ),
+        'no_suscrito'         => __( 'Sin suscripción', 'cdb-empleo' ),
+        'sin_suscripciones'   => __( 'Sin suscripciones', 'cdb-empleo' ),
+        'sin_permiso_form'    => __( 'Sin permisos', 'cdb-empleo' ),
+        'campos_requeridos'   => __( 'Campos requeridos', 'cdb-empleo' ),
+        'fecha_invalida'      => __( 'Fecha inválida', 'cdb-empleo' ),
+        'error_generico'      => __( 'Error genérico', 'cdb-empleo' ),
+        'error_solicitud'     => __( 'Error de solicitud', 'cdb-empleo' ),
+        'oferta_registrada'   => __( 'Oferta registrada', 'cdb-empleo' ),
+        'error_crear_oferta'  => __( 'Error al crear oferta', 'cdb-empleo' ),
+    );
+
+    if ( isset( $_POST['cdb_empleo_config_mensajes_nonce'] ) && wp_verify_nonce( $_POST['cdb_empleo_config_mensajes_nonce'], 'cdb_empleo_config_mensajes_save' ) ) {
+        foreach ( $mensajes as $clave => $label ) {
+            $texto      = isset( $_POST['cdb_empleo_mensaje_' . $clave] ) ? sanitize_text_field( $_POST['cdb_empleo_mensaje_' . $clave] ) : '';
+            $secundario = isset( $_POST['cdb_empleo_mensaje_' . $clave . '_secundario'] ) ? sanitize_text_field( $_POST['cdb_empleo_mensaje_' . $clave . '_secundario'] ) : '';
+            $tipo       = isset( $_POST['cdb_empleo_color_' . $clave] ) ? sanitize_text_field( $_POST['cdb_empleo_color_' . $clave] ) : 'aviso';
+            $mostrar    = isset( $_POST['cdb_empleo_mensaje_' . $clave . '_mostrar'] ) ? 1 : 0;
+
+            update_option( 'cdb_empleo_mensaje_' . $clave, $texto );
+            update_option( 'cdb_empleo_mensaje_' . $clave . '_secundario', $secundario );
+            update_option( 'cdb_empleo_color_' . $clave, $tipo );
+            update_option( 'cdb_empleo_mensaje_' . $clave . '_mostrar', $mostrar );
+        }
+
+        if ( isset( $_POST['tipos_color'] ) ) {
+            $tipos_nuevos = array();
+            foreach ( $_POST['tipos_color'] as $slug => $datos ) {
+                if ( isset( $datos['delete'] ) ) {
+                    continue;
+                }
+                $slug_sanitized = sanitize_key( $slug );
+                if ( isset( $tipos_nuevos[ $slug_sanitized ] ) ) {
+                    continue;
+                }
+                $tipo = array(
+                    'nombre' => sanitize_text_field( $datos['nombre'] ),
+                    'class'  => sanitize_html_class( $datos['class'] ),
+                    'color'  => sanitize_hex_color( $datos['color'] ),
+                    'text'   => sanitize_hex_color( $datos['text'] ),
+                );
+                if ( empty( $tipo['text'] ) && ! empty( $tipo['color'] ) ) {
+                    $tipo['text'] = cdb_empleo_get_contrasting_text_color( $tipo['color'] );
+                }
+                $tipos_nuevos[ $slug_sanitized ] = $tipo;
+            }
+            update_option( 'cdb_empleo_tipos_color', $tipos_nuevos );
+            $tipos_color = $tipos_nuevos;
+        }
+
+        echo '<div class="updated"><p>' . esc_html__( 'Ajustes guardados.', 'cdb-empleo' ) . '</p></div>';
+    }
+
+    echo '<div class="wrap"><h1>' . esc_html__( 'Configuración de Mensajes y Avisos', 'cdb-empleo' ) . '</h1>';
+    echo '<form method="post">';
+    wp_nonce_field( 'cdb_empleo_config_mensajes_save', 'cdb_empleo_config_mensajes_nonce' );
+
+    foreach ( $mensajes as $clave => $label ) {
+        $def   = $mensajes_defaults[ $clave ];
+        $texto = get_option( 'cdb_empleo_mensaje_' . $clave, $def['texto'] );
+        $sec   = get_option( 'cdb_empleo_mensaje_' . $clave . '_secundario', $def['secundario'] );
+        $tipo  = get_option( 'cdb_empleo_color_' . $clave, $def['tipo'] );
+        $mostrar = get_option( 'cdb_empleo_mensaje_' . $clave . '_mostrar', $def['mostrar'] );
+        echo '<div class="cdb-mensaje-row">';
+        echo '<h2>' . esc_html( $label ) . '</h2>';
+        echo '<div class="cdb-aviso-preview" id="preview_' . esc_attr( $clave ) . '">' . cdb_empleo_get_mensaje( $clave ) . '</div>';
+        echo '<p><label>' . esc_html__( 'Texto principal', 'cdb-empleo' ) . '<br><input type="text" class="cdb-mensaje-input" data-preview="preview_' . esc_attr( $clave ) . '" name="cdb_empleo_mensaje_' . esc_attr( $clave ) . '" value="' . esc_attr( $texto ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Texto secundario', 'cdb-empleo' ) . '<br><input type="text" class="cdb-mensaje-input" data-preview="preview_' . esc_attr( $clave ) . '" name="cdb_empleo_mensaje_' . esc_attr( $clave ) . '_secundario" value="' . esc_attr( $sec ) . '" /></label></p>';
+        echo '<p><label>' . esc_html__( 'Tipo / Color', 'cdb-empleo' ) . '<br><select name="cdb_empleo_color_' . esc_attr( $clave ) . '">';
+        foreach ( $tipos_color as $slug => $t ) {
+            echo '<option value="' . esc_attr( $slug ) . '" ' . selected( $tipo, $slug, false ) . '>' . esc_html( $t['nombre'] ) . '</option>';
+        }
+        echo '</select></label></p>';
+        echo '<p><label><input type="checkbox" class="cdb-mostrar-checkbox" data-preview="preview_' . esc_attr( $clave ) . '" name="cdb_empleo_mensaje_' . esc_attr( $clave ) . '_mostrar" value="1" ' . checked( $mostrar, 1, false ) . ' /> ' . esc_html__( 'Mostrar aviso', 'cdb-empleo' ) . '</label></p>';
+        echo '</div>';
+    }
+
+    echo '<h2>' . esc_html__( 'Tipos/Colores', 'cdb-empleo' ) . '</h2>';
+    echo '<div id="cdb-tipos-color">';
+    foreach ( $tipos_color as $slug => $info ) {
+        echo '<div class="cdb-tipo-color-row">';
+        echo '<span class="cdb-color-swatch" style="background-color: ' . esc_attr( $info['color'] ) . ';"></span>';
+        echo '<input type="text" name="tipos_color[' . esc_attr( $slug ) . '][nombre]" value="' . esc_attr( $info['nombre'] ) . '" />';
+        echo '<input type="text" name="tipos_color[' . esc_attr( $slug ) . '][class]" value="' . esc_attr( $info['class'] ) . '" />';
+        echo '<input type="color" name="tipos_color[' . esc_attr( $slug ) . '][color]" value="' . esc_attr( $info['color'] ) . '" />';
+        echo '<input type="color" name="tipos_color[' . esc_attr( $slug ) . '][text]" value="' . esc_attr( $info['text'] ) . '" />';
+        echo '<label><input type="checkbox" name="tipos_color[' . esc_attr( $slug ) . '][delete]" value="1" /> ' . esc_html__( 'Eliminar', 'cdb-empleo' ) . '</label>';
+        echo '</div>';
+    }
+    echo '</div>';
+    echo '<p><button type="button" class="button" id="cdb-add-tipo-color">' . esc_html__( 'Añadir tipo/color', 'cdb-empleo' ) . '</button></p>';
+
+    submit_button();
+    echo '</form></div>';
+}
+?>

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -1,0 +1,235 @@
+<?php
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+/**
+ * Default messages and helpers for configurable notices.
+ */
+
+function cdb_empleo_get_mensajes_defaults() {
+    return array(
+        'login_requerido' => array(
+            'texto'      => __( 'Debes iniciar sesión para realizar esta acción.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'ya_suscrito' => array(
+            'texto'      => __( 'Ya estás suscrito a esta oferta.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'info',
+            'mostrar'    => 1,
+        ),
+        'suscripcion_ok' => array(
+            'texto'      => __( '¡Te has suscrito correctamente a la oferta!', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'exito',
+            'mostrar'    => 1,
+        ),
+        'suscripcion_eliminada' => array(
+            'texto'      => __( 'Has eliminado tu suscripción a la oferta.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'info',
+            'mostrar'    => 1,
+        ),
+        'no_suscrito' => array(
+            'texto'      => __( 'No estás suscrito a ninguna oferta de empleo.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'info',
+            'mostrar'    => 1,
+        ),
+        'sin_ofertas' => array(
+            'texto'      => __( 'No hay ofertas disponibles.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'sin_suscripciones' => array(
+            'texto'      => __( 'No hay suscripciones para esta oferta.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'sin_permiso_form' => array(
+            'texto'      => __( 'No tienes permisos para realizar esta acción.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'campos_requeridos' => array(
+            'texto'      => __( 'Por favor, completa todos los campos requeridos.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'fecha_invalida' => array(
+            'texto'      => __( 'La fecha y hora de incorporación debe ser anterior a la fecha y hora de fin.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'error_generico' => array(
+            'texto'      => __( 'Ocurrió un error.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'error_solicitud' => array(
+            'texto'      => __( 'Error en la solicitud.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+        'oferta_registrada' => array(
+            'texto'      => __( 'Oferta de empleo registrada exitosamente.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'exito',
+            'mostrar'    => 1,
+        ),
+        'error_crear_oferta' => array(
+            'texto'      => __( 'Error al crear la oferta.', 'cdb-empleo' ),
+            'secundario' => '',
+            'tipo'       => 'aviso',
+            'mostrar'    => 1,
+        ),
+    );
+}
+
+/**
+ * Calculate a readable text color (black/white) for a given background.
+ */
+function cdb_empleo_get_contrasting_text_color( $hex ) {
+    $hex = ltrim( $hex, '#' );
+    if ( 3 === strlen( $hex ) ) {
+        $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+    }
+    $r   = hexdec( substr( $hex, 0, 2 ) );
+    $g   = hexdec( substr( $hex, 2, 2 ) );
+    $b   = hexdec( substr( $hex, 4, 2 ) );
+    $luma = ( 0.299 * $r + 0.587 * $g + 0.114 * $b ) / 255;
+    return ( $luma > 0.5 ) ? '#000000' : '#ffffff';
+}
+
+/**
+ * Obtain all registered notice types.
+ */
+function cdb_empleo_get_tipos_color() {
+    $defaults = array(
+        'aviso' => array(
+            'nombre' => __( 'Aviso', 'cdb-empleo' ),
+            'class'  => 'cdb-aviso-aviso',
+            'color'  => '#f0ad4e',
+            'text'   => '#000000',
+        ),
+        'info' => array(
+            'nombre' => __( 'Info', 'cdb-empleo' ),
+            'class'  => 'cdb-aviso-info',
+            'color'  => '#5bc0de',
+            'text'   => '#ffffff',
+        ),
+        'exito' => array(
+            'nombre' => __( 'Éxito', 'cdb-empleo' ),
+            'class'  => 'cdb-aviso-exito',
+            'color'  => '#5cb85c',
+            'text'   => '#ffffff',
+        ),
+    );
+
+    $tipos = get_option( 'cdb_empleo_tipos_color', array() );
+    $tipos = wp_parse_args( $tipos, $defaults );
+
+    foreach ( $tipos as $slug => &$datos ) {
+        if ( empty( $datos['class'] ) ) {
+            $datos['class'] = 'cdb-aviso-' . $slug;
+        }
+        if ( empty( $datos['nombre'] ) ) {
+            $datos['nombre'] = $slug;
+        }
+        if ( empty( $datos['text'] ) && ! empty( $datos['color'] ) ) {
+            $datos['text'] = cdb_empleo_get_contrasting_text_color( $datos['color'] );
+        }
+    }
+
+    return $tipos;
+}
+
+/**
+ * Register a new type/color programmatically.
+ */
+function cdb_empleo_register_tipo_color( $slug, $args ) {
+    if ( empty( $slug ) ) {
+        return;
+    }
+    $tipos = cdb_empleo_get_tipos_color();
+    $nuevo = wp_parse_args(
+        $args,
+        array(
+            'nombre' => $slug,
+            'class'  => 'cdb-aviso-' . $slug,
+            'color'  => '#cccccc',
+            'text'   => '',
+        )
+    );
+    if ( empty( $nuevo['text'] ) ) {
+        $nuevo['text'] = cdb_empleo_get_contrasting_text_color( $nuevo['color'] );
+    }
+    $tipos[ $slug ] = $nuevo;
+    update_option( 'cdb_empleo_tipos_color', $tipos );
+}
+
+/**
+ * Get CSS class for a type/color.
+ */
+function cdb_empleo_get_tipo_color_class( $slug ) {
+    $tipos = cdb_empleo_get_tipos_color();
+    return isset( $tipos[ $slug ] ) ? $tipos[ $slug ]['class'] : $tipos['aviso']['class'];
+}
+
+/**
+ * Return only the text of a message, without markup.
+ */
+function cdb_empleo_get_mensaje_text( $clave, $default = '' ) {
+    $defaults = cdb_empleo_get_mensajes_defaults();
+    if ( '' === $default && isset( $defaults[ $clave ] ) ) {
+        $default = $defaults[ $clave ]['texto'];
+    }
+    return get_option( 'cdb_empleo_mensaje_' . $clave, $default );
+}
+
+/**
+ * Build HTML for a message.
+ */
+function cdb_empleo_get_mensaje( $clave ) {
+    $defaults = cdb_empleo_get_mensajes_defaults();
+    if ( ! isset( $defaults[ $clave ] ) ) {
+        return '';
+    }
+    $def = $defaults[ $clave ];
+
+    $texto      = get_option( 'cdb_empleo_mensaje_' . $clave, $def['texto'] );
+    $secundario = get_option( 'cdb_empleo_mensaje_' . $clave . '_secundario', $def['secundario'] );
+    $tipo       = get_option( 'cdb_empleo_color_' . $clave, $def['tipo'] );
+    $mostrar    = get_option( 'cdb_empleo_mensaje_' . $clave . '_mostrar', $def['mostrar'] );
+
+    if ( ! $mostrar ) {
+        return '';
+    }
+
+    $class = cdb_empleo_get_tipo_color_class( $tipo );
+
+    $html  = '<div class="cdb-aviso ' . esc_attr( $class ) . '">';
+    $html .= '<span class="cdb-mensaje-principal">' . esc_html( $texto ) . '</span>';
+    if ( ! empty( $secundario ) ) {
+        $html .= ' <span class="cdb-mensaje-secundario">' . esc_html( $secundario ) . '</span>';
+    }
+    $html .= '</div>';
+
+    return $html;
+}
+
+function cdb_empleo_render_mensaje( $clave ) {
+    echo cdb_empleo_get_mensaje( $clave );
+}
+
+?>

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -7,13 +7,31 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Encola los estilos y scripts necesarios para el frontend del plugin.
  */
 function cdb_empleo_enqueue_scripts() {
-    // Encolar la hoja de estilos del plugin.
+    // Estilos base del plugin.
     wp_enqueue_style(
         'cdb-empleo-style',
         CDB_EMPLEO_URL . 'assets/css/estilo-ofertas.css',
         array(),
         '1.0.0'
     );
+
+    // Estilos para los avisos configurables.
+    wp_enqueue_style(
+        'cdb-empleo-mensajes',
+        CDB_EMPLEO_URL . 'assets/css/config-mensajes.css',
+        array(),
+        '1.0.0'
+    );
+
+    // Generar CSS dinámico para cada tipo de aviso.
+    $tipos = cdb_empleo_get_tipos_color();
+    $css   = '';
+    foreach ( $tipos as $slug => $t ) {
+        $css .= '.' . $t['class'] . '{background-color:' . $t['color'] . ';color:' . $t['text'] . ';}';
+    }
+    if ( $css ) {
+        wp_add_inline_style( 'cdb-empleo-mensajes', $css );
+    }
 
     // Cargar los scripts solo en páginas que utilicen el formulario de ofertas.
     if ( is_singular() ) {
@@ -30,10 +48,17 @@ function cdb_empleo_enqueue_scripts() {
             wp_localize_script(
                 'cdb-empleo-script',
                 'cdbEmpleo',
-                array( 'ajaxurl' => admin_url( 'admin-ajax.php' ) )
+                array(
+                    'ajaxurl'  => admin_url( 'admin-ajax.php' ),
+                    'mensajes' => array(
+                        'campos_requeridos' => cdb_empleo_get_mensaje_text( 'campos_requeridos' ),
+                        'fecha_invalida'    => cdb_empleo_get_mensaje_text( 'fecha_invalida' ),
+                        'error_generico'    => cdb_empleo_get_mensaje_text( 'error_generico' ),
+                        'error_solicitud'   => cdb_empleo_get_mensaje_text( 'error_solicitud' ),
+                    ),
+                )
             );
         }
     }
-
 }
 add_action( 'wp_enqueue_scripts', 'cdb_empleo_enqueue_scripts' );

--- a/includes/shortcodes.php
+++ b/includes/shortcodes.php
@@ -28,32 +28,32 @@ function cdb_empleo_listado_shortcode( $atts ) {
     $atts = shortcode_atts( array(
         'posts_per_page' => 10,
     ), $atts, 'cdb_listado_ofertas' );
-    
+
     $query_args = array(
         'post_type'      => 'oferta_empleo',
         'posts_per_page' => intval( $atts['posts_per_page'] ),
         'post_status'    => 'publish',
     );
-    
+
     $query = new WP_Query( $query_args );
     ob_start();
-    
+
     if ( $query->have_posts() ) {
         echo '<div class="ofertas-grid">';
         while ( $query->have_posts() ) {
             $query->the_post();
-            $bar_id = get_post_meta( get_the_ID(), 'cdb_bar', true );
-            $posicion_id = get_post_meta( get_the_ID(), 'cdb_posicion', true );
-            $tipo_oferta = get_post_meta( get_the_ID(), 'cdb_tipo_oferta', true );
-            $fecha_incorporacion = get_post_meta( get_the_ID(), 'cdb_fecha_incorporacion', true );
-            $fecha_fin = get_post_meta( get_the_ID(), 'cdb_fecha_fin', true );
-            
+            $bar_id             = get_post_meta( get_the_ID(), 'cdb_bar', true );
+            $posicion_id        = get_post_meta( get_the_ID(), 'cdb_posicion', true );
+            $tipo_oferta        = get_post_meta( get_the_ID(), 'cdb_tipo_oferta', true );
+            $fecha_incorporacion= get_post_meta( get_the_ID(), 'cdb_fecha_incorporacion', true );
+            $fecha_fin          = get_post_meta( get_the_ID(), 'cdb_fecha_fin', true );
+
             // Formatear las fechas con hora en formato 24h
-            $fecha_incorporacion_formatted = $fecha_incorporacion 
-                ? date_i18n( 'H:i \d\e\l l d \d\e F \d\e Y', strtotime( $fecha_incorporacion ) ) 
+            $fecha_incorporacion_formatted = $fecha_incorporacion
+                ? date_i18n( 'H:i \d\e\l l d \d\e F \d\e Y', strtotime( $fecha_incorporacion ) )
                 : '';
-            $fecha_fin_formatted = $fecha_fin 
-                ? date_i18n( 'H:i \d\e\l l d \d\e F \d\e Y', strtotime( $fecha_fin ) ) 
+            $fecha_fin_formatted = $fecha_fin
+                ? date_i18n( 'H:i \d\e\l l d \d\e F \d\e Y', strtotime( $fecha_fin ) )
                 : '';
             ?>
             <div class="oferta-card">
@@ -80,9 +80,9 @@ function cdb_empleo_listado_shortcode( $atts ) {
         echo '</div>';
         wp_reset_postdata();
     } else {
-        echo '<p>No hay ofertas disponibles.</p>';
+        echo cdb_empleo_get_mensaje( 'sin_ofertas' );
     }
-    
+
     return ob_get_clean();
 }
 add_shortcode( 'cdb_listado_ofertas', 'cdb_empleo_listado_shortcode' );
@@ -106,7 +106,7 @@ function cdb_oferta_suscripcion_shortcode( $atts ) {
 
     // Verificar si el usuario está logueado.
     if ( ! is_user_logged_in() ) {
-        return '<p>Debes iniciar sesión para suscribirte a esta oferta.</p>';
+        return cdb_empleo_get_mensaje( 'login_requerido' );
     }
 
     $user_id = get_current_user_id();
@@ -117,7 +117,7 @@ function cdb_oferta_suscripcion_shortcode( $atts ) {
 
     // Verificar si el usuario ya está suscrito.
     if ( in_array( $user_id, $suscripciones ) ) {
-        return '<p>Ya estás suscrito a esta oferta.</p>';
+        return cdb_empleo_get_mensaje( 'ya_suscrito' );
     }
 
     // Procesar la suscripción al recibir el formulario
@@ -128,7 +128,7 @@ function cdb_oferta_suscripcion_shortcode( $atts ) {
         $suscripciones[] = $user_id;
         update_post_meta( $oferta_id, '_cdb_oferta_inscripciones', $suscripciones );
 
-        return '<p>¡Te has suscrito correctamente a la oferta!</p>';
+        return cdb_empleo_get_mensaje( 'suscripcion_ok' );
     }
 
     // Mostrar el formulario de suscripción
@@ -169,7 +169,7 @@ function cdb_ofertas_inscripciones_meta_box_callback( $post ) {
 
     // Si no es un array o está vacío, mostramos un mensaje
     if ( ! is_array( $suscripciones ) || empty( $suscripciones ) ) {
-        echo '<p>No hay suscripciones para esta oferta.</p>';
+        echo cdb_empleo_get_mensaje( 'sin_suscripciones' );
         return;
     }
 
@@ -194,7 +194,7 @@ function cdb_ofertas_inscripciones_meta_box_callback( $post ) {
 function cdb_empleo_suscritos_shortcode( $atts ) {
     // Verificar que el usuario esté logueado
     if ( ! is_user_logged_in() ) {
-        return '<p>Debes iniciar sesión para ver tus ofertas suscritas.</p>';
+        return cdb_empleo_get_mensaje( 'login_requerido' );
     }
 
     $user_id = get_current_user_id();
@@ -217,7 +217,7 @@ function cdb_empleo_suscritos_shortcode( $atts ) {
         if ( $key !== false ) {
             unset( $suscripciones[$key] );
             update_post_meta( $oferta_id_to_remove, '_cdb_oferta_inscripciones', $suscripciones );
-            $mensaje_accion = '<p>Has eliminado tu suscripción a la oferta.</p>';
+            $mensaje_accion = cdb_empleo_get_mensaje( 'suscripcion_eliminada' );
         }
     }
 
@@ -241,7 +241,7 @@ function cdb_empleo_suscritos_shortcode( $atts ) {
 
     // 3) Si no hay ofertas, avisar
     if ( ! $query->have_posts() ) {
-        return $mensaje_accion . '<p>No estás suscrito a ninguna oferta de empleo.</p>';
+        return $mensaje_accion . cdb_empleo_get_mensaje( 'no_suscrito' );
     }
 
     // 4) Mostrar la lista de ofertas con posibilidad de eliminar la suscripción

--- a/templates/archive-oferta_empleo.php
+++ b/templates/archive-oferta_empleo.php
@@ -55,7 +55,7 @@ get_header(); ?>
         ?>
         
     <?php else : ?>
-        <p>No hay ofertas de empleo publicadas.</p>
+        <?php echo cdb_empleo_get_mensaje( 'sin_ofertas' ); ?>
     <?php endif; ?>
 </div>
 

--- a/templates/form-oferta-template.php
+++ b/templates/form-oferta-template.php
@@ -7,13 +7,13 @@ if ( ! defined( 'ABSPATH' ) ) {
 // Verificar si el usuario está conectado.
 $current_user = wp_get_current_user();
 if ( ! $current_user->exists() ) {
-    echo '<p>Debes iniciar sesión para gestionar ofertas de empleo.</p>';
+    echo cdb_empleo_get_mensaje( 'login_requerido' );
     return;
 }
 
 // Verificar si el usuario tiene el rol "Empleador" o "Administrator"
 if ( ! in_array( 'empleador', (array) $current_user->roles ) && ! in_array( 'administrator', (array) $current_user->roles ) ) {
-    echo '<p></p>';
+    echo cdb_empleo_get_mensaje( 'sin_permiso_form' );
     return;
 }
 


### PR DESCRIPTION
## Summary
- add centralized message registry with default texts and type/color helpers
- provide admin UI to customize notices and colors
- expose messages to JS and replace hard-coded strings across shortcodes, AJAX and templates
- allow adding, editing and removing custom notice color types from settings

## Testing
- `php -l includes/messages.php`
- `php -l includes/config-mensajes.php`


------
https://chatgpt.com/codex/tasks/task_e_6893c53bfb0083278910dfda4c819d42