### PR TITLE
Integrate message style variants and color row

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -1,7 +1,25 @@
-.cdb-aviso {
+.cdb-aviso,
+.cdb-aviso-aviso,
+.cdb-aviso-info,
+.cdb-aviso-exito {
     padding: 10px;
     border-radius: 4px;
     margin: 5px 0;
+}
+
+.cdb-aviso-aviso {
+    background-color: #f0ad4e;
+    color: #000000;
+}
+
+.cdb-aviso-info {
+    background-color: #5bc0de;
+    color: #ffffff;
+}
+
+.cdb-aviso-exito {
+    background-color: #5cb85c;
+    color: #ffffff;
 }
 .cdb-aviso .cdb-mensaje-principal {
     font-weight: bold;
@@ -10,7 +28,8 @@
     display: block;
     font-size: 0.9em;
 }
-.cdb-mensaje-row {
+.cdb-mensaje-row,
+.cdb-tipo-color-row {
     border: 1px solid #ddd;
     padding: 10px;
     margin-bottom: 15px;


### PR DESCRIPTION
## Summary
- group `.cdb-aviso` with its color variants and define default colors
- apply shared styling to both `.cdb-mensaje-row` and `.cdb-tipo-color-row`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6893d69c0fe883278ec51b9a86d8c06a