### PR TITLE
Evita duplicados de menú y normaliza tipos de aviso

### DIFF
--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -24,7 +24,7 @@ jQuery(document).ready(function($){
         var index = table.find('tr').length;
         var row = $('<tr />');
         row.append('<td><input type="text" name="tipos_color[' + index + '][slug]" /></td>');
-        row.append('<td><input type="text" name="tipos_color[' + index + '][nombre]" /></td>');
+        row.append('<td><input type="text" name="tipos_color[' + index + '][name]" /></td>');
         row.append('<td><input type="text" name="tipos_color[' + index + '][class]" /></td>');
         row.append('<td><input type="color" name="tipos_color[' + index + '][color]" value="#ffffff" /></td>');
         row.append('<td><input type="color" name="tipos_color[' + index + '][text]" value="#000000" /></td>');

--- a/includes/config-mensajes.php
+++ b/includes/config-mensajes.php
@@ -7,16 +7,19 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Register admin menu and page for message configuration.
  */
 function cdb_empleo_mensajes_admin_menu() {
-    // Ensure main menu exists
-    add_menu_page(
-        __( 'CdB Empleo', 'cdb-empleo' ),
-        __( 'CdB Empleo', 'cdb-empleo' ),
-        'manage_options',
-        'cdb-empleo',
-        '__return_null',
-        'dashicons-id',
-        26
-    );
+    // Ensure main menu exists only once.
+    global $admin_page_hooks;
+    if ( ! isset( $admin_page_hooks['cdb-empleo'] ) ) {
+        add_menu_page(
+            __( 'CdB Empleo', 'cdb-empleo' ),
+            __( 'CdB Empleo', 'cdb-empleo' ),
+            'manage_options',
+            'cdb-empleo',
+            '__return_null',
+            'dashicons-id',
+            26
+        );
+    }
 
     add_submenu_page(
         'cdb-empleo',
@@ -26,6 +29,9 @@ function cdb_empleo_mensajes_admin_menu() {
         'cdb-empleo-config-mensajes',
         'cdb_empleo_config_mensajes_page'
     );
+
+    // Remove duplicated submenu pointing to the top-level page.
+    remove_submenu_page( 'cdb-empleo', 'cdb-empleo' );
 }
 add_action( 'admin_menu', 'cdb_empleo_mensajes_admin_menu' );
 
@@ -87,10 +93,10 @@ function cdb_empleo_config_mensajes_page() {
                     continue;
                 }
                 $tipos_guardar[ $slug ] = array(
-                    'nombre' => isset( $tipo['nombre'] ) ? sanitize_text_field( $tipo['nombre'] ) : '',
-                    'class'  => isset( $tipo['class'] ) ? sanitize_text_field( $tipo['class'] ) : '',
-                    'color'  => isset( $tipo['color'] ) ? sanitize_hex_color( $tipo['color'] ) : '',
-                    'text'   => isset( $tipo['text'] ) ? sanitize_hex_color( $tipo['text'] ) : '',
+                    'name'  => isset( $tipo['name'] ) ? sanitize_text_field( $tipo['name'] ) : '',
+                    'class' => isset( $tipo['class'] ) ? sanitize_text_field( $tipo['class'] ) : '',
+                    'color' => isset( $tipo['color'] ) ? sanitize_hex_color( $tipo['color'] ) : '',
+                    'text'  => isset( $tipo['text'] ) ? sanitize_hex_color( $tipo['text'] ) : '',
                 );
             }
             update_option( 'cdb_empleo_tipos_color', $tipos_guardar );
@@ -116,7 +122,7 @@ function cdb_empleo_config_mensajes_page() {
         echo '<p><label>' . esc_html__( 'Texto secundario', 'cdb-empleo' ) . '<br><input type="text" class="cdb-mensaje-input" data-preview="preview_' . esc_attr( $clave ) . '" name="cdb_empleo_mensaje_' . esc_attr( $clave ) . '_secundario" value="' . esc_attr( $sec ) . '" /></label></p>';
         echo '<p><label>' . esc_html__( 'Tipo / Color', 'cdb-empleo' ) . '<br><select name="cdb_empleo_color_' . esc_attr( $clave ) . '">';
         foreach ( $tipos as $slug => $t ) {
-            echo '<option value="' . esc_attr( $slug ) . '" ' . selected( $tipo, $slug, false ) . '>' . esc_html( $t['nombre'] ) . '</option>';
+            echo '<option value="' . esc_attr( $slug ) . '" ' . selected( $tipo, $slug, false ) . '>' . esc_html( $t['name'] ) . '</option>';
         }
         echo '</select></label></p>';
         echo '<p><label><input type="checkbox" class="cdb-mostrar-checkbox" data-preview="preview_' . esc_attr( $clave ) . '" name="cdb_empleo_mensaje_' . esc_attr( $clave ) . '_mostrar" value="1" ' . checked( $mostrar, 1, false ) . ' /> ' . esc_html__( 'Mostrar aviso', 'cdb-empleo' ) . '</label></p>';
@@ -135,7 +141,7 @@ function cdb_empleo_config_mensajes_page() {
     foreach ( $tipos as $slug => $t ) {
         echo '<tr>';
         echo '<td><input type="text" name="tipos_color[' . $i . '][slug]" value="' . esc_attr( $slug ) . '" /></td>';
-        echo '<td><input type="text" name="tipos_color[' . $i . '][nombre]" value="' . esc_attr( $t['nombre'] ) . '" /></td>';
+        echo '<td><input type="text" name="tipos_color[' . $i . '][name]" value="' . esc_attr( $t['name'] ) . '" /></td>';
         echo '<td><input type="text" name="tipos_color[' . $i . '][class]" value="' . esc_attr( $t['class'] ) . '" /></td>';
         echo '<td><input type="color" name="tipos_color[' . $i . '][color]" value="' . esc_attr( $t['color'] ) . '" /></td>';
         echo '<td><input type="color" name="tipos_color[' . $i . '][text]" value="' . esc_attr( $t['text'] ) . '" /></td>';

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -102,26 +102,35 @@ function cdb_empleo_get_mensajes_defaults() {
 function cdb_empleo_get_tipos_color() {
     $defaults = array(
         'aviso' => array(
-            'nombre' => __( 'Aviso', 'cdb-empleo' ),
-            'class'  => 'cdb-aviso-aviso',
-            'color'  => '#f0ad4e',
-            'text'   => '#000000',
+            'name'  => __( 'Aviso', 'cdb-empleo' ),
+            'class' => 'cdb-aviso-aviso',
+            'color' => '#f0ad4e',
+            'text'  => '#000000',
         ),
         'info' => array(
-            'nombre' => __( 'Info', 'cdb-empleo' ),
-            'class'  => 'cdb-aviso-info',
-            'color'  => '#5bc0de',
-            'text'   => '#ffffff',
+            'name'  => __( 'Info', 'cdb-empleo' ),
+            'class' => 'cdb-aviso-info',
+            'color' => '#5bc0de',
+            'text'  => '#ffffff',
         ),
         'exito' => array(
-            'nombre' => __( 'Éxito', 'cdb-empleo' ),
-            'class'  => 'cdb-aviso-exito',
-            'color'  => '#5cb85c',
-            'text'   => '#ffffff',
+            'name'  => __( 'Éxito', 'cdb-empleo' ),
+            'class' => 'cdb-aviso-exito',
+            'color' => '#5cb85c',
+            'text'  => '#ffffff',
         ),
     );
 
     $tipos = get_option( 'cdb_empleo_tipos_color', array() );
+
+    // Normalize legacy keys.
+    foreach ( $tipos as &$t ) {
+        if ( isset( $t['nombre'] ) && ! isset( $t['name'] ) ) {
+            $t['name'] = $t['nombre'];
+            unset( $t['nombre'] );
+        }
+    }
+    unset( $t );
 
     return wp_parse_args( $tipos, $defaults );
 }
@@ -134,7 +143,7 @@ function cdb_empleo_register_tipo_color( $slug, $args ) {
         return;
     }
     $tipos = cdb_empleo_get_tipos_color();
-    $tipos[ $slug ] = wp_parse_args( $args, array( 'nombre' => $slug, 'class' => 'cdb-aviso-' . $slug, 'color' => '#cccccc', 'text' => '#000000' ) );
+    $tipos[ $slug ] = wp_parse_args( $args, array( 'name' => $slug, 'class' => 'cdb-aviso-' . $slug, 'color' => '#cccccc', 'text' => '#000000' ) );
     update_option( 'cdb_empleo_tipos_color', $tipos );
 }
 


### PR DESCRIPTION
## Summary
- Evitar duplicados del menú de administración comprobando si ya existe la página y eliminando la subpágina automática.
- Normalizar la gestión de tipos de aviso usando la clave `name` en los arrays y formularios.

## Testing
- `php -l includes/config-mensajes.php`
- `php -l includes/messages.php`
- `node --check assets/js/config-mensajes.js`
- `php -d display_errors=1 -r 'define("ABSPATH", __DIR__ . "/"); $admin_page_hooks=array(); function __($s,$d=null){return $s;} function add_menu_page($a,$b,$c,$slug,$cb,$icon,$pos){global $admin_page_hooks; echo "add_menu_page:$slug\n"; $admin_page_hooks[$slug]=true;} function add_submenu_page($parent,$a,$b,$cap,$slug,$cb){echo "add_submenu_page:$slug under $parent\n";} function remove_submenu_page($parent,$slug){echo "remove_submenu_page:$slug from $parent\n";} function add_action($hook,$cb){;} require "includes/config-mensajes.php"; cdb_empleo_mensajes_admin_menu(); cdb_empleo_mensajes_admin_menu(); echo "done\n";'`
- `php -r '$_POST["tipos_color"]=array(array("slug"=>"demo","name"=>"Demo","class"=>"cdb-demo","color"=>"#111111","text"=>"#222222")); $tipos_guardar=array(); foreach($_POST["tipos_color"] as $tipo){ $slug=isset($tipo["slug"]) ? $tipo["slug"] : ""; if(empty($slug)) continue; $tipos_guardar[$slug]=array( "name"=>isset($tipo["name"]) ? $tipo["name"] : "", "class"=>isset($tipo["class"]) ? $tipo["class"] : "", "color"=>isset($tipo["color"]) ? $tipo["color"] : "", "text"=>isset($tipo["text"]) ? $tipo["text"] : "" ); } print_r($tipos_guardar);'`


------
https://chatgpt.com/codex/tasks/task_e_6893dbff5e84832790551344e412dd4b