### PR TITLE
Normalize message type keys and add JS helpers

### DIFF
--- a/includes/messages.php
+++ b/includes/messages.php
@@ -143,6 +143,10 @@ function cdb_empleo_register_tipo_color( $slug, $args ) {
         return;
     }
     $tipos = cdb_empleo_get_tipos_color();
+    if ( isset( $args['nombre'] ) && ! isset( $args['name'] ) ) {
+        $args['name'] = $args['nombre'];
+        unset( $args['nombre'] );
+    }
     $tipos[ $slug ] = wp_parse_args( $args, array( 'name' => $slug, 'class' => 'cdb-aviso-' . $slug, 'color' => '#cccccc', 'text' => '#000000' ) );
     update_option( 'cdb_empleo_tipos_color', $tipos );
 }
@@ -195,6 +199,21 @@ function cdb_empleo_get_mensaje( $clave ) {
     $html .= '</div>';
 
     return $html;
+}
+
+/**
+ * Get message string prepared for JavaScript contexts.
+ */
+function cdb_empleo_get_mensaje_js( $clave ) {
+    return esc_js( cdb_empleo_get_mensaje_text( $clave ) );
+}
+
+/**
+ * Get default message text for translation extraction.
+ */
+function cdb_empleo_get_mensaje_i18n( $clave ) {
+    $defaults = cdb_empleo_get_mensajes_defaults();
+    return isset( $defaults[ $clave ] ) ? $defaults[ $clave ]['texto'] : '';
 }
 
 function cdb_empleo_render_mensaje( $clave ) {


### PR DESCRIPTION
## Summary
- Handle legacy `nombre` type keys when registering notice colors.
- Add helpers to retrieve messages for JS and translation contexts.

## Testing
- `find . -name "*.php" -print0 | xargs -0 -n 1 -P 4 php -l`
- `php -r 'define("ABSPATH",1); function __($t,$d){return $t;} function get_option($k,$d){return $d;} function esc_html($t){return $t;} function esc_attr($t){return $t;} function esc_js($t){return $t;} function wp_parse_args($a,$b=array()){return array_merge($b,(array)$a);} require "includes/messages.php"; echo cdb_empleo_get_mensaje("login_requerido"); echo "\n"; echo cdb_empleo_get_mensaje_js("login_requerido"); echo "\n"; echo cdb_empleo_get_mensaje_i18n("login_requerido"); echo "\n";'

------
https://chatgpt.com/codex/tasks/task_e_6893dfeeb92c832780f87976cdafab15