### PR TITLE
feat: add configurable borders and modern aviso markup

### DIFF
--- a/assets/css/config-mensajes.css
+++ b/assets/css/config-mensajes.css
@@ -1,32 +1,14 @@
-.cdb-aviso,
-.cdb-aviso-aviso,
-.cdb-aviso-info,
-.cdb-aviso-exito {
-    padding: 10px;
-    border-radius: 4px;
-    margin: 5px 0;
+.cdb-aviso{
+    padding:10px 15px;
+    margin:15px 0;
 }
-
-.cdb-aviso-aviso {
-    background-color: #f0ad4e;
-    color: #000000;
+.cdb-mensaje-destacado{
+    font-weight:700;
+    display:block;
 }
-
-.cdb-aviso-info {
-    background-color: #5bc0de;
-    color: #ffffff;
-}
-
-.cdb-aviso-exito {
-    background-color: #5cb85c;
-    color: #ffffff;
-}
-.cdb-aviso .cdb-mensaje-principal {
-    font-weight: bold;
-}
-.cdb-aviso .cdb-mensaje-secundario {
-    display: block;
-    font-size: 0.9em;
+.cdb-mensaje-secundario{
+    display:block;
+    font-size:.9em;
 }
 .cdb-mensaje-row,
 .cdb-tipo-color-row {

--- a/assets/js/config-mensajes.js
+++ b/assets/js/config-mensajes.js
@@ -1,21 +1,65 @@
 jQuery(document).ready(function($){
+    function updateMensajePreview(input){
+        var target = $('#' + $(input).data('preview'));
+        if(!target.length){return;}
+        var field = $(input).attr('name').indexOf('_secundario') !== -1 ? '.cdb-mensaje-secundario' : '.cdb-mensaje-destacado';
+        target.find(field).text($(input).val());
+    }
+
     $('.cdb-mensaje-input').on('input', function(){
-        var target = $('#' + $(this).data('preview'));
-        var html = '<div class="cdb-aviso">' + $(this).val() + '</div>';
+        updateMensajePreview(this);
+    });
+
+    $('select[name^="cdb_empleo_color_"]').on('change', function(){
+        var clave = $(this).attr('name').replace('cdb_empleo_color_','');
+        var target = $('#preview_' + clave + ' .cdb-aviso');
         if(target.length){
-            var existing = target.find('.cdb-aviso');
-            if(existing.length){
-                existing.find('.cdb-mensaje-principal').text($(this).val());
-            } else {
-                target.html(html);
-            }
+            var tipo = $(this).val();
+            target.attr('class','cdb-aviso cdb-aviso--' + tipo + ' cdb-aviso-' + tipo);
         }
     });
+
     $('.cdb-mostrar-checkbox').on('change', function(){
         var target = $('#' + $(this).data('preview'));
         if(target.length){
             target.toggle(this.checked);
         }
+    });
+
+    function updateTipoPreview(row){
+        var bg = row.find('input[name$="[bg]"]').val();
+        var text = row.find('input[name$="[text]"]').val();
+        var borderColor = row.find('input[name$="[border_color]"]').val();
+        var borderWidth = row.find('select[name$="[border_width]"]').val();
+        var borderRadius = row.find('select[name$="[border_radius]"]').val();
+        var preview = row.find('.cdb-aviso-preview');
+        preview.css({
+            'background-color': bg,
+            color: text,
+            'border-radius': borderRadius
+        });
+        if(borderWidth === '0px'){
+            preview.css({border:'none','border-left':'4px solid ' + borderColor});
+        }else{
+            preview.css({'border-left':'none','border': borderWidth + ' solid ' + borderColor});
+        }
+    }
+
+    $('.cdb-color-picker').wpColorPicker({
+        change: function(){
+            updateTipoPreview($(this).closest('tr'));
+        }
+    });
+    $('#cdb-tipos-color').on('change','select',function(){
+        updateTipoPreview($(this).closest('tr'));
+    });
+    $('#cdb-tipos-color').on('input','input',function(){
+        if($(this).hasClass('wp-color-picker')){return;}
+        updateTipoPreview($(this).closest('tr'));
+    });
+
+    $('#cdb-tipos-color tbody tr').each(function(){
+        updateTipoPreview($(this));
     });
 
     var table = $('#cdb-tipos-color tbody');
@@ -26,13 +70,24 @@ jQuery(document).ready(function($){
         row.append('<td><input type="text" name="tipos_color[' + index + '][slug]" /></td>');
         row.append('<td><input type="text" name="tipos_color[' + index + '][name]" /></td>');
         row.append('<td><input type="text" name="tipos_color[' + index + '][class]" /></td>');
-        row.append('<td><input type="color" name="tipos_color[' + index + '][color]" value="#ffffff" /></td>');
-        row.append('<td><input type="color" name="tipos_color[' + index + '][text]" value="#000000" /></td>');
+        row.append('<td><input type="text" class="cdb-color-picker" name="tipos_color[' + index + '][bg]" value="#ffffff" /></td>');
+        row.append('<td><input type="text" class="cdb-color-picker" name="tipos_color[' + index + '][text]" value="#000000" /></td>');
+        row.append('<td><input type="text" class="cdb-color-picker" name="tipos_color[' + index + '][border_color]" value="#ffffff" /></td>');
+        row.append('<td><select name="tipos_color[' + index + '][border_width]"><option value="0px">0px</option><option value="1px">1px</option><option value="2px">2px</option><option value="4px">4px</option></select></td>');
+        row.append('<td><select name="tipos_color[' + index + '][border_radius]"><option value="0px">0px</option><option value="4px">4px</option><option value="6px">6px</option><option value="8px">8px</option></select></td>');
+        row.append('<td><div class="cdb-aviso cdb-aviso-preview"><strong class="cdb-mensaje-destacado">Vista previa</strong><span class="cdb-mensaje-secundario"></span></div></td>');
         row.append('<td><button type="button" class="button cdb-remove-row">&times;</button></td>');
         table.append(row);
+        row.find('.cdb-color-picker').wpColorPicker({
+            change: function(){
+                updateTipoPreview(row);
+            }
+        });
+        updateTipoPreview(row);
     });
 
     $('#cdb-tipos-color').on('click', '.cdb-remove-row', function(){
         $(this).closest('tr').remove();
     });
 });
+

--- a/includes/messages.php
+++ b/includes/messages.php
@@ -102,33 +102,56 @@ function cdb_empleo_get_mensajes_defaults() {
 function cdb_empleo_get_tipos_color() {
     $defaults = array(
         'aviso' => array(
-            'name'  => __( 'Aviso', 'cdb-empleo' ),
-            'class' => 'cdb-aviso-aviso',
-            'color' => '#f0ad4e',
-            'text'  => '#000000',
+            'name'         => __( 'Aviso', 'cdb-empleo' ),
+            'class'        => 'cdb-aviso--aviso',
+            'bg'           => '#dc2626',
+            'text'         => '#ffffff',
+            'border_color' => '#dc2626',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
         ),
         'info' => array(
-            'name'  => __( 'Info', 'cdb-empleo' ),
-            'class' => 'cdb-aviso-info',
-            'color' => '#5bc0de',
-            'text'  => '#ffffff',
+            'name'         => __( 'Info', 'cdb-empleo' ),
+            'class'        => 'cdb-aviso--info',
+            'bg'           => '#5bc0de',
+            'text'         => '#ffffff',
+            'border_color' => '#5bc0de',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
         ),
         'exito' => array(
-            'name'  => __( 'Éxito', 'cdb-empleo' ),
-            'class' => 'cdb-aviso-exito',
-            'color' => '#5cb85c',
-            'text'  => '#ffffff',
+            'name'         => __( 'Éxito', 'cdb-empleo' ),
+            'class'        => 'cdb-aviso--exito',
+            'bg'           => '#5cb85c',
+            'text'         => '#ffffff',
+            'border_color' => '#5cb85c',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
         ),
     );
 
     $tipos = get_option( 'cdb_empleo_tipos_color', array() );
 
-    // Normalize legacy keys.
-    foreach ( $tipos as &$t ) {
+    // Normalize legacy keys and add new defaults.
+    foreach ( $tipos as $slug => &$t ) {
         if ( isset( $t['nombre'] ) && ! isset( $t['name'] ) ) {
             $t['name'] = $t['nombre'];
             unset( $t['nombre'] );
         }
+        if ( isset( $t['color'] ) && ! isset( $t['bg'] ) ) {
+            $t['bg'] = $t['color'];
+            unset( $t['color'] );
+        }
+        if ( ! isset( $t['class'] ) || false === strpos( $t['class'], 'cdb-aviso--' ) ) {
+            $t['class'] = 'cdb-aviso--' . $slug;
+        }
+        $t = wp_parse_args( $t, array(
+            'bg'           => isset( $defaults[ $slug ] ) ? $defaults[ $slug ]['bg'] : '#cccccc',
+            'text'         => isset( $defaults[ $slug ] ) ? $defaults[ $slug ]['text'] : '#000000',
+            'border_color' => isset( $defaults[ $slug ] ) ? $defaults[ $slug ]['border_color'] : '#cccccc',
+            'border_width' => '0px',
+            'border_radius'=> '4px',
+        ) );
     }
     unset( $t );
 
@@ -147,7 +170,19 @@ function cdb_empleo_register_tipo_color( $slug, $args ) {
         $args['name'] = $args['nombre'];
         unset( $args['nombre'] );
     }
-    $tipos[ $slug ] = wp_parse_args( $args, array( 'name' => $slug, 'class' => 'cdb-aviso-' . $slug, 'color' => '#cccccc', 'text' => '#000000' ) );
+    if ( isset( $args['color'] ) && ! isset( $args['bg'] ) ) {
+        $args['bg'] = $args['color'];
+        unset( $args['color'] );
+    }
+    $tipos[ $slug ] = wp_parse_args( $args, array(
+        'name'         => $slug,
+        'class'        => 'cdb-aviso--' . $slug,
+        'bg'           => '#cccccc',
+        'text'         => '#000000',
+        'border_color' => '#cccccc',
+        'border_width' => '0px',
+        'border_radius'=> '4px',
+    ) );
     update_option( 'cdb_empleo_tipos_color', $tipos );
 }
 
@@ -189,13 +224,12 @@ function cdb_empleo_get_mensaje( $clave ) {
         return '';
     }
 
-    $class = cdb_empleo_get_tipo_color_class( $tipo );
+    $class  = cdb_empleo_get_tipo_color_class( $tipo );
+    $legacy = 'cdb-aviso-' . $tipo;
 
-    $html  = '<div class="cdb-aviso ' . esc_attr( $class ) . '">';
-    $html .= '<span class="cdb-mensaje-principal">' . esc_html( $texto ) . '</span>';
-    if ( ! empty( $secundario ) ) {
-        $html .= ' <span class="cdb-mensaje-secundario">' . esc_html( $secundario ) . '</span>';
-    }
+    $html  = '<div class="cdb-aviso ' . esc_attr( $class ) . ' ' . esc_attr( $legacy ) . '">';
+    $html .= '<strong class="cdb-mensaje-destacado">' . esc_html( $texto ) . '</strong>';
+    $html .= '<span class="cdb-mensaje-secundario">' . esc_html( $secundario ) . '</span>';
     $html .= '</div>';
 
     return $html;

--- a/includes/scripts.php
+++ b/includes/scripts.php
@@ -27,7 +27,14 @@ function cdb_empleo_enqueue_scripts() {
     $tipos = cdb_empleo_get_tipos_color();
     $css   = '';
     foreach ( $tipos as $slug => $t ) {
-        $css .= '.' . $t['class'] . '{background-color:' . $t['color'] . ';color:' . $t['text'] . ';}';
+        $selector = '.cdb-aviso.' . $t['class'] . ', .cdb-aviso-' . $slug;
+        $css     .= $selector . '{background-color:' . $t['bg'] . ';color:' . $t['text'] . ';';
+        if ( '0px' === $t['border_width'] ) {
+            $css .= 'border:none;border-left:4px solid ' . $t['border_color'] . ';';
+        } else {
+            $css .= 'border:' . $t['border_width'] . ' solid ' . $t['border_color'] . ';';
+        }
+        $css .= 'border-radius:' . $t['border_radius'] . ';}';
     }
     if ( $css ) {
         wp_add_inline_style( 'cdb-empleo-mensajes', $css );


### PR DESCRIPTION
## Summary
- extend aviso type data with background, text and border options
- render notices with unified `.cdb-aviso--{tipo}` markup and legacy classes
- add admin controls with color pickers and live preview for border settings

## Testing
- `php -l includes/messages.php`
- `php -l includes/scripts.php`
- `php -l includes/config-mensajes.php`


------
https://chatgpt.com/codex/tasks/task_e_6895dea8ca8c8327a9da0b1f66b0d156